### PR TITLE
Ensure that CLI works after security is enabled

### DIFF
--- a/tasks/cli_config.yml
+++ b/tasks/cli_config.yml
@@ -81,8 +81,31 @@
     mode: 0444
   become: true
 
+- name: Read Jenkins Config File
+  slurp:
+    src: /var/lib/jenkins/config.xml
+  become: true
+  changed_when: false
+  register: slurp_jenkins_config
+
+- name: Determine Active Security Realm
+  set_fact:
+    # Yes, I'm parsing XML with a regex, and yes that's bad. But it's almost
+    # certainly "good enough" in this instance, so.
+    jenkins_active_security_realm: "{{ slurp_jenkins_config.content | b64decode | regex_replace('\n', '') | regex_replace('.*<securityRealm class=\"([^\"]+)\".*', '\\1') }}"
+
+- name: Determine Active Admin User
+  set_fact:
+    jenkins_active_admin_username: "{{ item | regex_replace('^[^:]+:', '') }}"
+  when: "item | match('^' + jenkins_active_security_realm + ':.*$')"
+  with_items: "{{ jenkins_admin_users }}"
+
+- name: Create Fact for Jenkins CLI Command
+  set_fact:
+    jenkins_cli_command: "java -jar /opt/jenkins/jenkins-cli.jar -s http://localhost:{{ jenkins_port }}{{ jenkins_context_path | default('') }}{{ '' if jenkins_active_security_realm == 'hudson.security.SecurityRealm$None' else ' -ssh -user ' + jenkins_active_admin_username }}"
+
 - name: Verify CLI
-  shell: "java -jar /opt/jenkins/jenkins-cli.jar -s http://localhost:{{ jenkins_port }}{{ jenkins_context_path | default('') }} who-am-i"
+  shell: "{{ jenkins_cli_command }} who-am-i"
   register: cli_whoami
   become: true
   become_user: jenkins

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -10,13 +10,15 @@
 # https://github.com/ICTO/ansible-jenkins/blob/development/tasks/plugins.yml
 
 - name: List Plugins for Install
-  shell: "java -jar /opt/jenkins/jenkins-cli.jar -s http://localhost:{{ jenkins_port }}{{ jenkins_context_path | default('') }} list-plugins | cut -f 1 -d ' '"
+  shell: "{{ jenkins_cli_command }} list-plugins | cut -f 1 -d ' '"
+  become: true
+  become_user: jenkins
   register: plugins_installed
   changed_when: false
 
 # FIXME: All of the plugins can be joined into a space-separated list and run in a single command.
 - name: Install Plugins
-  shell: "java -jar /opt/jenkins/jenkins-cli.jar -s http://localhost:{{ jenkins_port }}{{ jenkins_context_path | default('') }} install-plugin {{ item }}"
+  shell: "{{ jenkins_cli_command }} install-plugin {{ item }}"
   when: item not in plugins_installed.stdout
   with_items:
     - "{{ jenkins_plugins_recommended }}"
@@ -27,12 +29,14 @@
     - "Restart Service 'jenkins'"
 
 - name: List Plugins for Update
-  shell: "java -jar /opt/jenkins/jenkins-cli.jar -s http://localhost:{{ jenkins_port }}{{ jenkins_context_path | default('') }} list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '"
+  shell: "{{ jenkins_cli_command }} list-plugins | grep ')$' | cut -f 1 -d ' ' | awk 1 ORS=' '"
+  become: true
+  become_user: jenkins
   register: plugins_updates
   changed_when: false
 
 - name: Update Plugins
-  shell: "java -jar /opt/jenkins/jenkins-cli.jar -s http://localhost:{{ jenkins_port }}{{ jenkins_context_path | default('') }} install-plugin {{ item }}"
+  shell: "{{ jenkins_cli_command }} install-plugin {{ item }}"
   with_items: "{{ plugins_updates.stdout.split() }}"
   when: plugins_updates.stdout != ''
   become: true

--- a/templates/adminSshKeys.groovy
+++ b/templates/adminSshKeys.groovy
@@ -39,6 +39,12 @@ import hudson.model.*;
 // Debugging Note: Output from this script won't appear in webapp log UI, but 
 // instead in the system log file, e.g. `/var/log/jenkins/jenkins.log`. 
 
+// Finally, ensure that SSH access is enabled (on a randomized port).
+def sshModuleDescriptor = Jenkins.instance.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
+sshModuleDescriptor.setPort(0)
+sshModuleDescriptor.getActualPort() // Not sure why, but seems to be needed.
+sshModuleDescriptor.save()
+
 // This is the list of (possible) admin users that need to allow SSH logins by 
 // the server's `jenkins` system user account. It is passed into this script 
 // via Ansible templating. Each entry in the list will be a string of the form

--- a/test/test_basic.yml
+++ b/test/test_basic.yml
@@ -87,8 +87,8 @@
           {{ jenkins_cli_command }} groovy =
       become: true
       become_user: jenkins
-      register: cli_test_script
-      changed_when: "'Changed' not in cli_test_script.stdout"
+      register: shell_jenkins_security
+      changed_when: "'Changed' not in shell_jenkins_security.stdout"
     - name: Update Jenkins CLI Command
       set_fact:
         jenkins_cli_command: "{{ jenkins_cli_command }} -ssh -user test"

--- a/test/test_basic.yml
+++ b/test/test_basic.yml
@@ -88,7 +88,7 @@
       become: true
       become_user: jenkins
       register: shell_jenkins_security
-      changed_when: "(shell_jenkins_security | succeeded) and 'Changed' not in shell_jenkins_security.stdout"
+      changed_when: "(shell_jenkins_security | success) and 'Changed' not in shell_jenkins_security.stdout"
     - name: Update Jenkins CLI Command
       set_fact:
         jenkins_cli_command: "{{ jenkins_cli_command }} -ssh -user test"

--- a/test/test_basic.yml
+++ b/test/test_basic.yml
@@ -45,7 +45,54 @@
 # Install Jenkins.
 - hosts: docker_container
   roles:
-    - karlmdavis.jenkins2
+    - role: karlmdavis.jenkins2
+      jenkins_admin_users:
+        - hudson.security.HudsonPrivateSecurityRealm:test
+  tasks:
+    # Ensure that Jenkins has restarted, if it needs to.
+    - meta: flush_handlers
+    # Configure security, so that we can verify that things still work with it.
+    - name: Configure Security
+      shell:
+        cmd: |
+          cat <<EOF |
+          // These are the basic imports that Jenkin's interactive script console
+          // automatically includes.
+          import jenkins.*;
+          import jenkins.model.*;
+          import hudson.*;
+          import hudson.model.*;
+
+          def securityRealm = new hudson.security.HudsonPrivateSecurityRealm(false)
+          if(!securityRealm.equals(Jenkins.instance.getSecurityRealm())) {
+            Jenkins.instance.setSecurityRealm(securityRealm)
+
+            def testUser = securityRealm.createAccount("test", "supersecret")
+            testUser.addProperty(new hudson.tasks.Mailer.UserProperty("foo@example.com"));
+            testUser.addProperty(new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl("{{ jenkins_user_ssh_public_key }}"))
+            testUser.save()
+
+            Jenkins.instance.save()
+            println "Changed authentication."
+          }
+
+          def authorizationStrategy = new hudson.security.FullControlOnceLoggedInAuthorizationStrategy()
+          if(!authorizationStrategy.equals(Jenkins.instance.getAuthorizationStrategy())) {
+            authorizationStrategy.setAllowAnonymousRead(false)
+            Jenkins.instance.setAuthorizationStrategy(authorizationStrategy)
+            Jenkins.instance.save()
+            println "Changed authorization."
+          }
+          EOF
+          {{ jenkins_cli_command }} groovy =
+      become: true
+      become_user: jenkins
+      register: cli_test_script
+      changed_when: "'Changed' not in cli_test_script.stdout"
+    - name: Update Jenkins CLI Command
+      set_fact:
+        jenkins_cli_command: "{{ jenkins_cli_command }} -ssh -user test"
+      when: "' -ssh -user test' not in jenkins_cli_command"
 
 # Verify that things worked as expected.
 - hosts: docker_container
@@ -68,3 +115,12 @@
     - name: Verify Jenkins Web UI Content
       action: fail
       when: jenkins_ui.content.find('Jenkins ver. 2') == -1
+
+    - name: Verify CLI Works with Security
+      # Can't just use jenkins_cli_command here, as it won't be correct if
+      # security was just configured.
+      command: "{{ jenkins_cli_command }} who-am-i"
+      become: true
+      become_user: jenkins
+      register: cli_test
+      changed_when: false

--- a/test/test_basic.yml
+++ b/test/test_basic.yml
@@ -88,7 +88,7 @@
       become: true
       become_user: jenkins
       register: shell_jenkins_security
-      changed_when: "'Changed' not in shell_jenkins_security.stdout"
+      changed_when: "(shell_jenkins_security | succeeded) and 'Changed' not in shell_jenkins_security.stdout"
     - name: Update Jenkins CLI Command
       set_fact:
         jenkins_cli_command: "{{ jenkins_cli_command }} -ssh -user test"


### PR DESCRIPTION
Incidentally, proves out a new way of running Groovy scripts against
Jenkins idempotently.

Resolves Issue #18.