### PR TITLE
issue-42: Add timeout support for plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ This role supports the following variables, listed here with their default value
     * These would be in addition to the plugins recommended by Jenkins 2's new setup wizard, which are installed automatically by this role (see `jenkins_plugins_recommended` in [defaults/main.yml](defaults/main.yml)).
 * `jenkins_java_args_extra`: `''`
     * Additional options that will be added to `JAVA_ARGS` for the Jenkins process, such as the JVM memory settings, e.g. `-Xmx4g`.
+* `jenkins_plugin_timeout`: `'60'`
+    * Defines the amount of time in seconds, before a plugin install will fail. This value is passed to the timeout parameter in jenkins_plugin module. http://docs.ansible.com/ansible/latest/jenkins_plugin_module.html#options 
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ This role supports the following variables, listed here with their default value
 * `jenkins_plugins_extra`: `[]`
     * Override this variable to install additional Jenkins plugins.
     * These would be in addition to the plugins recommended by Jenkins 2's new setup wizard, which are installed automatically by this role (see `jenkins_plugins_recommended` in [defaults/main.yml](defaults/main.yml)).
+* `jenkins_plugins_timeout`: `60`
+    * The amount of time (in seconds) before a plugin install/update will fail. This value is passed to the timeout parameter in `jenkins_plugin` module. (See here for details: <http://docs.ansible.com/ansible/latest/jenkins_plugin_module.html#options>.)
 * `jenkins_java_args_extra`: `''`
     * Additional options that will be added to `JAVA_ARGS` for the Jenkins process, such as the JVM memory settings, e.g. `-Xmx4g`.
-* `jenkins_plugin_timeout`: `'60'`
-    * Defines the amount of time in seconds, before a plugin install will fail. This value is passed to the timeout parameter in jenkins_plugin module. http://docs.ansible.com/ansible/latest/jenkins_plugin_module.html#options 
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,9 @@ jenkins_plugins_recommended:
 # (must be overridden).
 jenkins_plugins_extra: []
 
+# Timeout when installing/updating plugins (in seconds).
+jenkins_plugins_timeout: 60
+
 # Additional options that will be added to JAVA_ARGS
 jenkins_java_args_extra: ''
 
@@ -72,6 +75,3 @@ jenkins_packages_url_base: 'https://pkg.jenkins.io'
 
 # Set to `true` to add a `proxy: _none_` setting for the YUM repo.
 jenkins_packages_repo_yum_disable_proxy: false
-
-# Timeout when installing the plugin in seconds
-jenkins_plugin_timeout: 60

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,5 @@ jenkins_packages_url_base: 'https://pkg.jenkins.io'
 # Set to `true` to add a `proxy: _none_` setting for the YUM repo.
 jenkins_packages_repo_yum_disable_proxy: false
 
+# Timeout when installing the plugin in seconds
+jenkins_plugin_timeout: 60

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -8,11 +8,11 @@
     state: present
     jenkins_home: "{{ jenkins_home }}"
     url: "{{ jenkins_url_local }}"
-    timeout: "{{ jenkins_plugin_timeout | default(60) }}"
     params:
       url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
     url_password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     validate_certs: "{{ false if ansible_distribution_release == 'trusty' else true }}"
+    timeout: "{{ jenkins_plugins_timeout }}"
   with_items:
     - "{{ jenkins_plugins_recommended }}"
     - "{{ jenkins_plugins_extra }}"
@@ -26,11 +26,11 @@
     state: latest
     jenkins_home: "{{ jenkins_home }}"
     url: "{{ jenkins_url_local }}"
-    timeout: "{{ jenkins_plugin_timeout | default(60) }}"
     params:
       url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
     url_password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     validate_certs: "{{ false if ansible_distribution_release == 'trusty' else true }}"
+    timeout: "{{ jenkins_plugins_timeout }}"
   with_items:
     - "{{ jenkins_plugins_recommended }}"
     - "{{ jenkins_plugins_extra }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,5 +1,5 @@
 ---
-# Installs the "standard" Jenkins 2.0 plugins, as well as any additional that 
+# Installs the "standard" Jenkins 2.0 plugins, as well as any additional that
 # are specified in the 'plugins_extra' variable.
 
 - name: Install Plugins
@@ -8,6 +8,7 @@
     state: present
     jenkins_home: "{{ jenkins_home }}"
     url: "{{ jenkins_url_local }}"
+    timeout: "{{ jenkins_plugin_timeout | default(60) }}"
     params:
       url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
     url_password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
@@ -25,6 +26,7 @@
     state: latest
     jenkins_home: "{{ jenkins_home }}"
     url: "{{ jenkins_url_local }}"
+    timeout: "{{ jenkins_plugin_timeout | default(60) }}"
     params:
       url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
     url_password: "{{ jenkins_dynamic_admin_password | default(omit) }}"


### PR DESCRIPTION
Consider adding support for timeout. Whilst testing on a somewhat slow machine, one of the plugins failed to install in time.