### PR TITLE
Support Jenkins' proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ This role supports the following variables, listed here with their default value
     * If `true`, the Jenkins plugins will be updated when this role is run. (Note that missing plugins will always be installed.)
 * `jenkins_java_args_extra`: `''`
     * Additional options that will be added to `JAVA_ARGS` for the Jenkins process, such as the JVM memory settings, e.g. `-Xmx4g`.
+* `jenkins_http_proxy_server`, `jenkins_http_proxy_port`, `jenkins_http_proxy_no_proxy_hosts`: (all undefined)
+    * These server the same function as the JVM's `http.proxyHost`, `http.proxyPort`, and `http.nonProxyHosts` system properties, except that the settings will be used for both HTTP and HTTPS requests.
+    * Specifically, these settings will be used to configure:
+        * The Jenkins JVM's `http.proxyHost`, `http.proxyPort`, `https.proxyHost`, `https.proxyPort`, and `http.nonProxyHosts` system properties, as documented on [Java Networking and Proxies](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html).
+        * The Jenkins-specific proxy settings (which some plugins, such as the [GitHub plugin](https://wiki.jenkins.io/display/JENKINS/Github+Plugin), require), as documented on [JenkinsBehindProxy](https://wiki.jenkins.io/display/JENKINS/JenkinsBehindProxy).
+        * The value of `jenkins_http_proxy_no_proxy_hosts` should be a list, e.g. `['localhost', 'example.com']`.
 
 Dependencies
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,7 +70,7 @@
       // and also initialize the slave agent.
       if (Jenkins.instance.slaveAgentPort != 0) {
         Jenkins.instance.slaveAgentPort=0
-        println "Changed slave agent configuration."
+        println "Changed: slave agent configuration."
       }
 
       // Set the Jenkins external URL, if defined.
@@ -81,7 +81,30 @@
       if (externalUrl != locationConfig.url) {
         locationConfig.url = externalUrl
         locationConfig.save()
-        println "Changed external URL"
+        println "Changed: external URL."
+      }
+
+      // Set the Jenkins proxy config, if defined.
+      def proxyName = "{{ jenkins_http_proxy_server | default('') | trim }}"
+      def proxyPortText = "{{ jenkins_http_proxy_port | default('') | trim }}"
+      def proxyNoProxyHosts = "{{ jenkins_http_proxy_no_proxy_hosts | default([]) | join('\n') }}"
+      if (proxyName == "") {
+        if (Jenkins.instance.proxy != null) {
+          Jenkins.instance.proxy = null
+          ProxyConfiguration.getXmlFile().delete()
+          println "Changed: removed proxy configuration"
+        }
+      } else if (
+          Jenkins.instance.proxy == null
+          || Jenkins.instance.proxy.name != proxyName
+          || "" + Jenkins.instance.proxy.port != proxyPortText
+          || Jenkins.instance.proxy.noProxyHost != proxyNoProxyHosts
+      ) {
+        try { proxyPort = Integer.parseInt(proxyPortText) } catch(NumberFormatException e) { throw new IllegalArgumentException("Invalid proxy port: ${proxyPortText}", e) }
+        proxyDesired = new ProxyConfiguration(proxyName, proxyPort, null, null, proxyNoProxyHosts)
+        proxyDesired.save()
+        Jenkins.instance.proxy = ProxyConfiguration.load()
+        println "Changed: proxy configuration."
       }
   register: shell_jenkins_config_misc
   changed_when: "(shell_jenkins_config_misc | success) and 'Changed' in shell_jenkins_config_misc.output"

--- a/tasks/packages_RedHat.yml
+++ b/tasks/packages_RedHat.yml
@@ -51,7 +51,7 @@
       # Note: The setup wizard has to be disabled before Jenkins runs the first
       # time. Fortunately, the RHEL packages don't automatically start the
       # Jenkins service after install, so we have time to address this.
-      line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false {{ jenkins_java_args_extra }}\""
+      line: "JENKINS_JAVA_OPTIONS=\"-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false {{ '' if (jenkins_http_proxy_server | default('') | trim) == '' else '-Dhttp.proxyHost={0} -Dhttps.proxyHost={0}'.format(jenkins_http_proxy_server) }} {{ '' if (jenkins_http_proxy_port | default('') | trim) == '' else '-Dhttp.proxyPort={0} -Dhttps.proxyPort={0}'.format(jenkins_http_proxy_port) }} {{ '' if (jenkins_http_proxy_no_proxy_hosts | default('') | trim) == '' else '-Dhttp.nonProxyHosts={}'.format(jenkins_http_proxy_no_proxy_hosts | join('|')) }} {{ jenkins_java_args_extra }}\""
     - regexp: '^JENKINS_PORT='
       line: "JENKINS_PORT={{ jenkins_port }}"
     - regexp: '^JENKINS_HOME='

--- a/templates/etc_default_jenkins_Debian.j2
+++ b/templates/etc_default_jenkins_Debian.j2
@@ -15,6 +15,11 @@ JAVA_ARGS="-Djava.awt.headless=true"
 # Ansible.
 JAVA_ARGS="${JAVA_ARGS} -Djenkins.install.runSetupWizard=false"
 
+# Specify addition JVM HTTP/HTTPS proxy system properties, if configured by the Ansible role.
+JAVA_ARGS="${JAVA_ARGS}{{ '' if (jenkins_http_proxy_server | default('') | trim) == '' else ' -Dhttp.proxyHost={0} -Dhttps.proxyHost={0}'.format(jenkins_http_proxy_server) }}"
+JAVA_ARGS="${JAVA_ARGS}{{ '' if (jenkins_http_proxy_port | default('') | trim) == '' else ' -Dhttp.proxyPort={0} -Dhttps.proxyPort={0}'.format(jenkins_http_proxy_port) }}"
+JAVA_ARGS="${JAVA_ARGS}{{ '' if (jenkins_http_proxy_no_proxy_hosts | default('') | trim) == '' else ' -Dhttp.nonProxyHosts={}'.format(jenkins_http_proxy_no_proxy_hosts) | join('|') }}"
+
 # Additional args specified by user of Ansible role.
 JAVA_ARGS="${JAVA_ARGS} {{ jenkins_java_args_extra }}"
 


### PR DESCRIPTION
Previously, I'd just been manually setting the relevant JVM system properties, as needed. Unfortunately, though, some Jenkins plugins require the Jenkins-specific proxy config. Oh well.

Issue #49