### PR TITLE
Fix of most up to date ansible version Error jenkins_plugin params

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -8,8 +8,7 @@
     state: present
     jenkins_home: "{{ jenkins_home }}"
     url: "{{ jenkins_url_local }}"
-    params:
-      url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
+    url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
     url_password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     validate_certs: "{{ false if ansible_distribution_release == 'trusty' else true }}"
     timeout: "{{ jenkins_plugins_timeout }}"
@@ -26,8 +25,7 @@
     state: latest
     jenkins_home: "{{ jenkins_home }}"
     url: "{{ jenkins_url_local }}"
-    params:
-      url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
+    url_username: "{{ jenkins_dynamic_admin_username | default(omit) }}"
     url_password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     validate_certs: "{{ false if ansible_distribution_release == 'trusty' else true }}"
     timeout: "{{ jenkins_plugins_timeout }}"


### PR DESCRIPTION
Error: The params option to jenkins_plugin was removed in Ansible 2.5since it circumvents Ansible's option handling
Solution: resolved params keyword