### PR TITLE
Try to find only 'Jenkins' in the login page

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,8 +188,10 @@
     no_proxy: localhost
   register: jenkins_ui
 
-- debug:
+- name: Debug Jenkins UI Content
+  debug:
     var: jenkins_ui
+
 - name: Verify Jenkins Web UI Content
   action: fail
   when: jenkins_ui.content.find('Jenkins') == -1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -190,5 +190,5 @@
 
 - name: Verify Jenkins Web UI Content
   action: fail
-  when: jenkins_ui.content.find('Jenkins ver. 2') == -1
+  when: jenkins_ui.content.find('Jenkins') == -1
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -194,4 +194,4 @@
 
 - name: Verify Jenkins Web UI Content
   action: fail
-  when: jenkins_ui.content.find('Jenkins') == -1
+  when: "'Jenkins' not in jenkins_ui.content"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,10 +188,6 @@
     no_proxy: localhost
   register: jenkins_ui
 
-- name: Debug Jenkins UI Content
-  debug:
-    var: jenkins_ui
-
 - name: Verify Jenkins Web UI Content
   action: fail
   when: "'Jenkins' not in jenkins_ui.content"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,7 +188,8 @@
     no_proxy: localhost
   register: jenkins_ui
 
+- debug:
+    var: jenkins_ui
 - name: Verify Jenkins Web UI Content
   action: fail
   when: jenkins_ui.content.find('Jenkins') == -1
-

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,7 +16,7 @@ source venv/bin/activate
 ansible-playbook $TEST_PLAY --inventory=inventory --syntax-check
 
 # Run the Ansible test case.
-ansible-playbook $TEST_PLAY --inventory=inventory
+ansible-playbook $TEST_PLAY --inventory=inventory -vvvv
 
 # Run the role/playbook again, checking to make sure it's idempotent.
 ansible-playbook $TEST_PLAY --inventory=inventory \

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,7 +16,7 @@ source venv/bin/activate
 ansible-playbook $TEST_PLAY --inventory=inventory --syntax-check
 
 # Run the Ansible test case.
-ansible-playbook $TEST_PLAY --inventory=inventory -vvvv
+ansible-playbook $TEST_PLAY --inventory=inventory
 
 # Run the role/playbook again, checking to make sure it's idempotent.
 ansible-playbook $TEST_PLAY --inventory=inventory \

--- a/test/test_basic.yml
+++ b/test/test_basic.yml
@@ -118,7 +118,7 @@
     
     - name: Verify Jenkins Web UI Content
       action: fail
-      when: jenkins_ui.content.find('Jenkins ver. 2') == -1
+      when: "'Jenkins' not in jenkins_ui.content"
 
     - name: Verify jenkins_script Works with Security
       jenkins_script:
@@ -140,4 +140,3 @@
       register: script_test_2
       changed_when: false
       failed_when: "'Hello World!' not in script_test_2.output"
-


### PR DESCRIPTION
Jenkins changed its login page template in 2.128 (https://issues.jenkins-ci.org/browse/JENKINS-50447).
The Jenkins version is no longer in the login page so the role fails with the most recent version of Jenkins.

